### PR TITLE
[TERMAPI-222] Add new get state button for our TAPI POST /actions endpoint action "get_state"

### DIFF
--- a/components/RunFlowsPage.tsx
+++ b/components/RunFlowsPage.tsx
@@ -11,6 +11,7 @@ import {
     runTransaction,
     useTransactionStatusMonitoring,
     toggleScreensaver,
+    getState
 } from "../terminal-api/checkout.ts";
 import { refund } from "../terminal-api/refunds.ts";
 import { useCustomerServiceMonitoring } from "../terminal-api/customer.ts";
@@ -106,6 +107,11 @@ export default function RunFlowsPage(props: Props) {
   const onClickSkipCurrentScreen = () => {
     skipCurrentScreen(config, logger, delay)
       .finally(() => console.log('Attempting to skip current screen'))
+  }
+
+  const onClickGetState = () => {
+    getState(config, logger, delay)
+      .finally(() => console.log('Attempting to get state'))
   }
 
   const onClickRefund = () => {
@@ -268,6 +274,12 @@ export default function RunFlowsPage(props: Props) {
               name="skipScreen"
               onClick={onClickSkipCurrentScreen}
             >Skip Current Screen</Button>
+          </div>
+          <div class={tw`flex gap-2 w-full justify-center pt-3`}>
+            <Button
+              name="getState"
+              onClick={onClickGetState}
+            >Get State</Button>
           </div>
           <div class={tw`flex gap-2 w-full justify-left pt-1`}>
             <input

--- a/terminal-api/checkout.ts
+++ b/terminal-api/checkout.ts
@@ -42,6 +42,9 @@ export const skipCurrentScreen = (config: ConfigurationSchema, logger: ILogger, 
 
 export const toggleScreensaver = (screensaver: boolean, config: ConfigurationSchema, logger: ILogger, delayInMillis: number
     ) => httpRequest('actions', "POST", `{"action": "toggle_screensaver", "data": {"screensaver_enabled": ${screensaver}}}`, config, logger, delayInMillis)
+    
+export const getState = (config: ConfigurationSchema, logger: ILogger, delayInMillis: number
+    ) => httpRequest('actions', "POST", '{"action": "get_state"}', config, logger, delayInMillis)
 
 export function useTransactionStatusMonitoring(
     posCheckoutId: string | undefined, config: ConfigurationSchema, logger: ILogger,


### PR DESCRIPTION
[TERMAPI-222](https://sumupteam.atlassian.net/browse/TERMAPI-222)

- Adding the ability to get the state of the app.

<img width="1718" alt="Untitled 3" src="https://github.com/fivestars/typescript-terminal-api/assets/104937320/1820386d-3d37-4043-9bec-c71be5129bc1">


[TERMAPI-222]: https://sumupteam.atlassian.net/browse/TERMAPI-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ