### PR TITLE
[TERMAPI-244] Remove custom user agent header

### DIFF
--- a/terminal-api/utils.ts
+++ b/terminal-api/utils.ts
@@ -82,7 +82,6 @@ export async function httpRequest(
       headers: {
         "Authorization": `Basic ${encode(config.basic_token)}`,
         "pos-id": `${config.pos_id}`,
-        "User-agent": "TapiDenoSampleClient",
         "Content-Type": "application/json",
         "Accept": "application/json",
         "fivestars-software-id": `${config.software_id}`,


### PR DESCRIPTION
[TERMAPI-244](https://sumupteam.atlassian.net/browse/TERMAPI-244)

Remove custom user agent header.

`User-Agent` header used to be on a famous list of forbidden headers, which means that they cannot be modified programmatically in order to prevent security vulnerabilities or conflicts. When the `User-Agent` header was removed from the list of forbidden headers, the paths diverged: Chromium-based browsers still thinks it is an unsafe header, while Firefox (as an example) has no problems with it.

Because this difference may cause errors and would not let us use properly our custom `User-Agent` header, it has been decided to remove it.

[TERMAPI-244]: https://sumupteam.atlassian.net/browse/TERMAPI-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ