### PR TITLE
[TERMAPI-255] Update versions and fix legacy compat problems

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
     "start": "deno run -A --watch=static/,routes/ dev.ts",
+    "start-reload": "deno run -A -r --watch=static/,routes/ dev.ts",
     "browser": "google-chrome --args --user-data-dir='/tmp/chrome_dev_test' --disable-web-security --no-sandbox --headless",
     "browser-mac": "open -n -a /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --args --user-data-dir='/tmp/chrome_dev_test' --disable-web-security",
     "tx-ping": "deno run --allow-read --allow-env --allow-net scripts/ping.ts",

--- a/import_map.json
+++ b/import_map.json
@@ -1,13 +1,16 @@
 {
   "imports": {
-    "$fresh/": "https://deno.land/x/fresh@1.0.1/",
-    "preact": "https://esm.sh/preact@10.8.2",
-    "preact/": "https://esm.sh/preact@10.8.2/",
-    "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.2.0?deps=preact@10.8.2",
+    "$fresh/": "https://deno.land/x/fresh@1.2.0/",
+    "preact": "https://esm.sh/preact@10.16.0",
+    "preact/": "https://esm.sh/preact@10.16.0/",
+    "react": "https://esm.sh/@preact/legacy-compat?external=preact",
+    "react-dom": "https://esm.sh/@preact/legacy-compat?external=preact",
+    "create-react-class": "https://esm.sh/@preact/legacy-compat?external=preact",
+    "preact-render-to-string": "https://esm.sh/preact-render-to-string@6.2.0?external=preact",
     "@twind": "./utils/twind.ts",
     "twind": "https://esm.sh/twind@0.16.17",
     "styled-components": "https://esm.sh/styled-components@5.3.5",
     "twind/": "https://esm.sh/twind@0.16.17/",
-    "react-json-inspector": "https://esm.sh/react-json-inspector@7.1.1?alias=react:preact/compat,react/jsx-runtime:preact/compat/jsx-runtime&deps=preact@10.8.2"
+    "react-json-inspector": "https://esm.sh/react-json-inspector@7.1.1"
   }
 }


### PR DESCRIPTION
Updates have been made to keep it up to date with libraries. Also, the project used to make use of `react-json-inspector` to render JSON data which hasn't been updated in the last 6 years. Because of that it uses some very old React APIs that have been removed from the normal `preact/compat` layer. Instead of outright dropping support for these, the community moved those older APIs to https://github.com/preactjs/legacy-compat/.

Aliasing to `preactjs/legacy-compat` instead of `preact/compat` would fix the issues we were having with the `Uncaught TypeError: _4.__ is not a function at E (hooks.js:2:3344) at Array.forEach (<anonymous>) at R (hooks.js:2:2157)` error.

We can try later on to remove `react-json-inspector` and see if we can replace it with another library that would suit our needs in a better or similar way.